### PR TITLE
feat(util): 비밀번호 해싱 및 비교 함수 추가

### DIFF
--- a/src/utils/hashUtil.ts
+++ b/src/utils/hashUtil.ts
@@ -1,0 +1,21 @@
+import bcrypt from 'bcryptjs';
+
+class HashUtil {
+  /**
+   * 평문 문자열을 입력받아 해쉬된 문자열을 반환합니다
+   */
+  hashPassword = (password: string): String => {
+    return bcrypt.hashSync(password, 10);
+  };
+
+  /**
+   * @param password  사용자한테 받은 평문 비밀번호
+   * @param hash DB에 저장된 해쉬된 비밀번호
+   * @returns 입력받은 값이 저장할때 원본 값과 같으면 true, 일치하지 않으면 false 리턴
+   */
+  checkPassword = (password: string, hash: string): Boolean => {
+    return bcrypt.compareSync(password, hash); // boolean
+  };
+}
+
+export default new HashUtil();


### PR DESCRIPTION
### 비밀번호 유틸

1. HashUtil 인스턴스를 import 합니다 [import HashUtil from '경로' 로 임포트 했다고 가정]
2. HashUtil.hashPassword(password: string)를 사용하여 비밀번호를 해시처리합니다.
3. HashUtil.checkPassword(password: string, hash: string)을 사용하여 저장된 비밀번호와 입력받은 비밀번호를 비교합니다.

### 예시
const hashedPW = HashUtil.hashPassword(userPassword)

if(HashUtil.checkPassword(userPassword, dbPassword)){
  ...
}
