### PR TITLE
refactor(prisma): Meeting 모델을 Meetings로 이름 변경 및 관련 코드 수정

### DIFF
--- a/prisma/migrations/20250822055442_chage_name_meetings/migration.sql
+++ b/prisma/migrations/20250822055442_chage_name_meetings/migration.sql
@@ -1,0 +1,26 @@
+/*
+  Warnings:
+
+  - You are about to drop the `Meeting` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- DropForeignKey
+ALTER TABLE "public"."Meeting" DROP CONSTRAINT "Meeting_contractId_fkey";
+
+-- DropTable
+DROP TABLE "public"."Meeting";
+
+-- CreateTable
+CREATE TABLE "public"."Meetings" (
+    "id" SERIAL NOT NULL,
+    "date" TIMESTAMP(3) NOT NULL,
+    "alarms" TEXT[],
+    "contractId" INTEGER NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Meetings_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "public"."Meetings" ADD CONSTRAINT "Meetings_contractId_fkey" FOREIGN KEY ("contractId") REFERENCES "public"."Contract"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -92,13 +92,13 @@ model Contract {
   userId         Int
   company        Company            @relation(fields: [companyId], references: [id], onDelete: Cascade, onUpdate: Cascade)
   companyId      Int
-  meeting        Meeting[]
+  meetings        Meetings[]
   document       ContractDocument[]
   createdAt      DateTime           @default(now())
   updatedAt      DateTime           @updatedAt
 }
 
-model Meeting {
+model Meetings {
   id         Int      @id @default(autoincrement())
   date       DateTime
   alarms     String[]

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -24,7 +24,7 @@ async function main() {
       "Car", 
       "CarModel", 
       "Contract", 
-      "Meeting", 
+      "Meetings", 
       "ContractDocument" 
     RESTART IDENTITY CASCADE
   `;
@@ -121,12 +121,12 @@ async function main() {
 
   // 미팅 데이터 삽입
   console.log('📅 미팅 데이터를 삽입합니다...');
-  for (const meeting of MEETINGS) {
-    await prisma.meeting.create({
+  for (const meetings of MEETINGS) {
+    await prisma.meetings.create({
       data: {
-        date: new Date(meeting.date),
-        alarms: meeting.alarms,
-        contractId: meeting.contractId,
+        date: new Date(meetings.date),
+        alarms: meetings.alarms,
+        contractId: meetings.contractId,
       },
     });
   }


### PR DESCRIPTION
프론트엔트 코드와의 모델명 통일을 위해서
Meeting 모델의 이름을 Meetings로 수정하였습니다.

관련 migrate및 seeding 코드도 통일하였습니다.