### PR TITLE
feat(contract): 계약 등록 API 추가

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -13,6 +13,7 @@ app.use(cors());
 app.use(express.json());
 app.use(cookieParser());
 
+app.use('/api/contracts', contractRouter);
 app.use(errorHandler);
 
 app.listen(process.env.PORT || 3000, () => console.log('Server Starting...'));

--- a/src/app.ts
+++ b/src/app.ts
@@ -2,6 +2,7 @@ import * as dotenv from 'dotenv';
 import cors from 'cors';
 import cookieParser from 'cookie-parser';
 import express, { Express } from 'express';
+import contractRouter from './routes/contractRouter';
 
 dotenv.config();
 
@@ -10,5 +11,6 @@ const app: Express = express();
 app.use(cors());
 app.use(express.json());
 app.use(cookieParser());
+app.use('/api/contracts', contractRouter);
 
 app.listen(process.env.PORT || 3000, () => console.log('Server Starting...'));

--- a/src/controllers/contractController.ts
+++ b/src/controllers/contractController.ts
@@ -1,4 +1,5 @@
 import { Request, Response } from 'express';
+import { createContractDTO } from '../types/contractType';
 import contractService from '../services/contractService';
 
 class ContractController {
@@ -18,6 +19,13 @@ class ContractController {
     const userId = req.user!.userId;
     const users = await contractService.getUsersInCompany(userId);
     res.status(200).json(users);
+  };
+
+  createContract = async (req: Request<{}, {}, createContractDTO>, res: Response) => {
+    const userId = req.user!.userId;
+    const { carId, customerId, meetings } = req.body;
+    const contract = await contractService.createContract(userId, carId, customerId, meetings);
+    res.status(201).json(contract);
   };
 }
 

--- a/src/repositories/contractRepository.ts
+++ b/src/repositories/contractRepository.ts
@@ -1,5 +1,6 @@
 import prisma from '../libs/prisma';
 import { meetingsDTO, carPriceDTO } from '../types/contractType';
+import { CustomError } from '../utils/customErrorUtil';
 
 class ContractRepository {
   getCompanyId = async (userId: number) => {
@@ -14,7 +15,7 @@ class ContractRepository {
       },
     });
     if (!user || !user.company) {
-      throw new Error();
+      throw CustomError.badRequest();
     }
     return user.company.id;
   };

--- a/src/repositories/contractRepository.ts
+++ b/src/repositories/contractRepository.ts
@@ -1,4 +1,5 @@
 import prisma from '../libs/prisma';
+import { meetingsDTO, carPriceDTO } from '../types/contractType';
 
 class ContractRepository {
   getCompanyId = async (userId: number) => {
@@ -33,13 +34,12 @@ class ContractRepository {
     return cars;
   };
 
-  getCar = async (carId: number) => {
+  getCarPrice = async (carId: number) => {
     const car = await prisma.car.findUnique({
       where: { id: carId },
       select: {
         id: true,
         price: true,
-        model: true,
       },
     });
     return car;
@@ -89,6 +89,62 @@ class ContractRepository {
       },
     });
     return user;
+  };
+
+  createContract = async (
+    userId: number,
+    car: carPriceDTO,
+    customerId: number,
+    companyId: number,
+    meetings: meetingsDTO[],
+  ) => {
+    const contract = await prisma.contract.create({
+      data: {
+        status: 'carInspection',
+        contractPrice: car.price,
+        car: {
+          connect: {
+            id: car.id,
+          },
+        },
+        customer: {
+          connect: {
+            id: customerId,
+          },
+        },
+        user: {
+          connect: {
+            id: userId,
+          },
+        },
+        company: {
+          connect: {
+            id: companyId,
+          },
+        },
+        meetings: {
+          createMany: {
+            data: meetings,
+          },
+        },
+      },
+      select: {
+        id: true,
+        status: true,
+        resolutionDate: true,
+        contractPrice: true,
+        meetings: {
+          select: {
+            date: true,
+            alarms: true,
+          },
+        },
+        user: { select: { id: true, name: true } },
+        customer: { select: { id: true, name: true } },
+        car: { select: { id: true, model: true } },
+      },
+    });
+    return contract;
   };
 }
 

--- a/src/routes/contractRouter.ts
+++ b/src/routes/contractRouter.ts
@@ -3,7 +3,7 @@ import contractController from '../controllers/contractController';
 
 const contractRouter = express.Router();
 
-contractRouter.route('/');
+contractRouter.route('/').post(contractController.createContract);
 
 contractRouter.route('/cars').get(contractController.getCarsForContract);
 
@@ -12,3 +12,5 @@ contractRouter.route('/customers').get(contractController.getCustomersForContrac
 contractRouter.route('/users').get(contractController.getUsersForContract);
 
 contractRouter.route('/:contractId');
+
+export default contractRouter;

--- a/src/routes/contractRouter.ts
+++ b/src/routes/contractRouter.ts
@@ -1,15 +1,24 @@
 import express from 'express';
 import contractController from '../controllers/contractController';
+import auth from '../middlewares/auth';
 
 const contractRouter = express.Router();
 
-contractRouter.route('/').post(contractController.createContract);
+contractRouter
+  .route('/')
+  .post(auth.verifyAccessToken, auth.verifyUserAuth, contractController.createContract);
 
-contractRouter.route('/cars').get(contractController.getCarsForContract);
+contractRouter
+  .route('/cars')
+  .get(auth.verifyAccessToken, auth.verifyUserAuth, contractController.getCarsForContract);
 
-contractRouter.route('/customers').get(contractController.getCustomersForContract);
+contractRouter
+  .route('/customers')
+  .get(auth.verifyAccessToken, auth.verifyUserAuth, contractController.getCustomersForContract);
 
-contractRouter.route('/users').get(contractController.getUsersForContract);
+contractRouter
+  .route('/users')
+  .get(auth.verifyAccessToken, auth.verifyUserAuth, contractController.getUsersForContract);
 
 contractRouter.route('/:contractId');
 

--- a/src/services/contractService.ts
+++ b/src/services/contractService.ts
@@ -1,5 +1,5 @@
 import contractRepository from '../repositories/contractRepository';
-import { ListItemDTO } from '../types/contractType';
+import { ListItemDTO, meetingsDTO } from '../types/contractType';
 
 class ContractService {
   getCarsInCompany = async (userId: number) => {
@@ -39,6 +39,30 @@ class ContractService {
       data: `${user.name}(${user.email})`,
     }));
     return formattedUsers;
+  };
+
+  createContract = async (
+    userId: number,
+    carId: number,
+    customerId: number,
+    meetings: meetingsDTO[],
+  ) => {
+    const companyId = await contractRepository.getCompanyId(userId);
+    if (!companyId) {
+      throw new Error();
+    }
+    const car = await contractRepository.getCarPrice(carId);
+    if (!car) {
+      throw new Error();
+    }
+    const contract = await contractRepository.createContract(
+      userId,
+      car,
+      customerId,
+      companyId,
+      meetings,
+    );
+    return contract;
   };
 }
 

--- a/src/services/contractService.ts
+++ b/src/services/contractService.ts
@@ -1,12 +1,10 @@
 import contractRepository from '../repositories/contractRepository';
 import { ListItemDTO, meetingsDTO } from '../types/contractType';
+import { CustomError } from '../utils/customErrorUtil';
 
 class ContractService {
   getCarsInCompany = async (userId: number) => {
     const companyId = await contractRepository.getCompanyId(userId);
-    if (!companyId) {
-      throw new Error();
-    }
     const cars = await contractRepository.getCarList(companyId);
     const formattedCars: ListItemDTO[] = cars.map((car) => ({
       id: car.id,
@@ -17,9 +15,6 @@ class ContractService {
 
   getCustomersInCompany = async (userId: number) => {
     const companyId = await contractRepository.getCompanyId(userId);
-    if (!companyId) {
-      throw new Error();
-    }
     const customers = await contractRepository.getCustomerList(companyId);
     const formattedCustomers: ListItemDTO[] = customers.map((customer) => ({
       id: customer.id,
@@ -30,9 +25,6 @@ class ContractService {
 
   getUsersInCompany = async (userId: number) => {
     const companyId = await contractRepository.getCompanyId(userId);
-    if (!companyId) {
-      throw new Error();
-    }
     const users = await contractRepository.getUserList(companyId);
     const formattedUsers: ListItemDTO[] = users.map((user) => ({
       id: user.id,
@@ -48,12 +40,9 @@ class ContractService {
     meetings: meetingsDTO[],
   ) => {
     const companyId = await contractRepository.getCompanyId(userId);
-    if (!companyId) {
-      throw new Error();
-    }
     const car = await contractRepository.getCarPrice(carId);
     if (!car) {
-      throw new Error();
+      throw CustomError.badRequest();
     }
     const contract = await contractRepository.createContract(
       userId,

--- a/src/types/contractType.ts
+++ b/src/types/contractType.ts
@@ -2,3 +2,19 @@ export interface ListItemDTO {
   id: number;
   data: string;
 }
+
+export interface meetingsDTO {
+  date: string;
+  alarms: string[];
+}
+
+export interface carPriceDTO {
+  id: number;
+  price: number;
+}
+
+export interface createContractDTO {
+  carId: number;
+  customerId: number;
+  meetings: meetingsDTO[];
+}


### PR DESCRIPTION
### **주요 변경사항**

- **계약 등록 기능 구현**: 명세서에 맞춰 계약 등록(POST /contracts) API를 구현했습니다. 요청 바디의 `carId`, `customerId`, `meetings` 데이터를 활용하여 새로운 계약을 생성하고 데이터베이스에 저장합니다.
- **유저 정보 활용**: `Authorization` 헤더의 Bearer 토큰을 통해 유저 ID와 소속 회사 정보를 추출하여 `userId`로 활용하고, 해당 유저의 회사에 귀속된 계약을 생성하도록 로직을 구현했습니다.
- **응답 데이터 일치**: 성공 시 `201 Created` 응답을 반환하며, 명세서에 정의된 계약 정보(ID, 상태, 가격, 날짜, 사용자, 고객, 차량 정보 등)를 포함하도록 응답 형식을 맞췄습니다.
- **상태 값 자동 설정**: 신규 계약의 상태는 명세서에 따라 `carInspection`으로 자동 설정됩니다.
- **차량 가격 반영**: 계약 가격(**`contractPrice`**)은 해당 `carId`에 연결된 차량의 가격으로 자동 설정됩니다.
- **날짜 값 처리**: `resolutionDate`는 초기 등록 시 `null`로 설정됩니다.

---

### **명세서 반영 상세 내용**

- **Request**
    - **헤더**: `Authorization: Bearer token`을 통해 인증된 사용자 정보를 검증하고, 해당 토큰에 포함된 유저 ID를 추출하여 계약 생성에 활용합니다.
    - **바디**: `carId`, `customerId`, `meetings` 필드를 필수로 받으며, 데이터 유효성 검사를 통해 명세서에 정의된 형식을 준수하도록 했습니다.
- **Response**
    - **201 Created**: 성공적으로 계약이 생성되면 상태 코드 201을 반환하며, `id`, `status`, `resolutionDate`, `contractPrice`, `meetings`, `user`, `customer`, `car` 정보를 포함하는 응답을 보냅니다.
    - **400 Bad Request**: 필수 필드가 누락되거나 데이터 형식이 올바르지 않으면 400 Bad Request 응답을 반환하고 "잘못된 요청입니다" 메시지를 포함합니다.
    - **401 Unauthorized**: 토큰이 유효하지 않거나 누락된 경우 401 Unauthorized 응답을 반환하고 "로그인이 필요합니다" 메시지를 포함합니다.

### 생각 해볼 점

- 차량 데이터 검증
    - 현재 차량 데이터가 **‘possession’**인 상태만 조회 되어 사용되기 때문에 따로 검증을 하지 않지만 생성 할 때에도 따로 검증할 필요가 있는지 검토 필요