### PR TITLE
feat(auth): 인증 로그인, 토큰갱신 API 추가

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -3,6 +3,7 @@ import cors from 'cors';
 import cookieParser from 'cookie-parser';
 import express, { Express } from 'express';
 import { errorHandler } from './middlewares/errorHandler';
+import authRouter from './routes/authRoute';
 
 dotenv.config();
 
@@ -11,6 +12,8 @@ const app: Express = express();
 app.use(cors());
 app.use(express.json());
 app.use(cookieParser());
+
+app.use('/auth', authRouter);
 
 app.use(errorHandler);
 

--- a/src/controllers/authController.ts
+++ b/src/controllers/authController.ts
@@ -1,0 +1,60 @@
+import { Request, Response } from 'express';
+import userService from '../services/userService';
+import authService from '../services/authService';
+import { LoginDTO, UserDTO } from '../types/userType';
+import { utilValidator } from '../validators/utilValidator';
+import { object, create } from 'superstruct';
+import { TokenDTO } from '../types/authType';
+
+class AuthController {
+  login = async (req: Request, res: Response) => {
+    // 1. DTO 정의
+    const loginDTO: LoginDTO = {
+      email: req.body.email as string,
+      password: req.body.password as string,
+    };
+    // 2. 유효성 검사
+    const loginStruct = object({
+      email: utilValidator.email,
+      password: utilValidator.password,
+    });
+    create(loginDTO, loginStruct);
+
+    // 3-1. DB에서 저장된 유저 조회 - 서비스 함수 호출
+    const user = await userService.getUser(loginDTO);
+
+    // 3-2. token 발행을 위한 유저 id 값 가공
+    const tokenDTO: TokenDTO = {
+      userId: user.id,
+    };
+    // 3-3. accessToken, refreshToken 발행 및 업데이트
+    const accessToken = authService.createToken(tokenDTO);
+    const refreshToken = authService.createToken(tokenDTO, 'refresh');
+    const updatedUser: UserDTO = await userService.updateUser({ refreshToken }, user.id);
+
+    // 4. 반환값을 가공하여 response를 돌려줍니다
+    const filteredUser = userService.filterSensitiveUserData(updatedUser);
+    return res.status(200).json({ user: filteredUser, accessToken, refreshToken });
+  };
+
+  updateToken = async (req: Request, res: Response) => {
+    // 1. DTO 정의 - 개별적으로 사용하기에 생략
+    const userRefreshToken: string = req.body.refreshToken as string;
+    const userId: number = req.auth!.userId;
+    // 2. 유효성 검사 - 이 미들웨어가 호출되기 전 verifyRefreshToken이 호출되므로 생략
+    // 3. 서비스 함수 호출
+    // 3-1. token 발행을 위한 유저 id 값 가공, verifyRefreshToken이 호출되므로 req.auth.userId가 존재함
+    const tokenDTO: TokenDTO = {
+      userId: req.auth!.userId,
+    };
+    // 3-2. refreshingAccessToken에서 현재 전달받은 토큰이 유효한지 검증
+    const accessToken = await authService.refreshingAccessToken(userId, userRefreshToken);
+    const refreshToken = authService.createToken(tokenDTO, 'refresh');
+    // 3.3 새로 refreshToken을 발급받았으므로 DB도 업데이트
+    await userService.updateUser({ refreshToken }, userId);
+    // 4. 토큰 반환
+    return res.status(200).json({ accessToken, refreshToken });
+  };
+}
+
+export default new AuthController();

--- a/src/middlewares/auth.ts
+++ b/src/middlewares/auth.ts
@@ -36,40 +36,26 @@ const verifyRefreshToken = expressjwt({
  * 에러 핸들러에서 처리 예정
  * 따라서 verifyAccessToken을 먼저 수행하고 에러가 없다면
  * 이미 로그인이 된 상태입니다.
- * 토큰은 유효하나 DB에는 제거해서 없을수도 있으므로 한번 검사
+ * 토큰은 유효하나 DB에는 제거해서 없을수도 있으므로 한번더 검사
  * */
 const verifyUserAuth = async (req: Request, res: Response, next: NextFunction) => {
   const userId = req.user!.userId;
-  try {
-    const user = await userRepository.getById(userId);
-
-    if (!user) {
-      throw CustomError.notFound('존재하지 않는 유저입니다.');
-    }
-
-    next();
-  } catch (error) {
-    next(error);
-  }
+  await userRepository.getById(userId);
+  next();
 };
 
 /**
  * 어드민 권한 확인하는 곳이 많으므로 별도 미들웨어로 분리
- * 반드시 verifyUserAuth 뒤에 호출되어야 함
+ * 에러를 던지는 로직이 userRepository에 있으므로
+ * verifyUserAuth는 호출되지 않아도 됩니다.
  * */
 const verifyAdminAuth = async (req: Request, res: Response, next: NextFunction) => {
   const userId = req.user!.userId;
-  try {
-    const user = await userRepository.getById(userId);
-
-    if (!user.isAdmin) {
-      throw CustomError.forbidden('관리자 권한이 필요합니다.');
-    }
-
-    next();
-  } catch (error) {
-    next(error);
+  const user = await userRepository.getById(userId);
+  if (!user.isAdmin) {
+    throw CustomError.unauthorized('관리자 권한이 필요합니다.');
   }
+  next();
 };
 
 export default {

--- a/src/middlewares/auth.ts
+++ b/src/middlewares/auth.ts
@@ -5,7 +5,7 @@ import { CustomError } from '../utils/customErrorUtil';
 
 const secret = process.env.JWT_SECRET;
 if (!secret) {
-  throw new Error('JWT_SECRET is not defined in the environment variables.');
+  throw new CustomError('JWT_SECRET is not defined in the environment variables.', 500);
 }
 
 /**

--- a/src/repositories/userRepository.ts
+++ b/src/repositories/userRepository.ts
@@ -1,6 +1,6 @@
 import prisma from '../libs/prisma';
-import { User } from '../generated/prisma';
 import { CustomError } from '../utils/customErrorUtil';
+import { UpdateUserDto, UserDTO } from '../types/userType';
 
 class UserRepository {
   /**
@@ -8,16 +8,87 @@ class UserRepository {
    * @param id userId 를 받습니다
    * @returns 해당하는 user가 있는 경우 해당 유저의 정보를 리턴, 없는 경우 error을 throw합니다.
    */
-  getById = async (id: number): Promise<User> => {
-    const user: User | null = await prisma.user.findUnique({
-      where: { id },
+  getById = async (userId: number): Promise<UserDTO> => {
+    const user: UserDTO | null = await prisma.user.findUnique({
+      where: { id: userId },
+      select: {
+        id: true,
+        name: true,
+        email: true,
+        password: true,
+        employeeNumber: true,
+        phoneNumber: true,
+        imageUrl: true,
+        isAdmin: true,
+        company: {
+          select: {
+            companyCode: true,
+          },
+        },
+        refreshToken: true,
+      },
     });
-
     if (!user) {
       throw CustomError.notFound('존재하지 않는 유저입니다.');
     }
-
     return user;
+  };
+
+  /**
+   *
+   * @param email email 를 받습니다
+   * @returns 해당하는 user가 있는 경우 해당 유저의 정보를 리턴, 없는 경우 error을 throw합니다.
+   */
+  getByEmail = async (email: string): Promise<UserDTO> => {
+    const user: UserDTO | null = await prisma.user.findUnique({
+      where: { email },
+      select: {
+        id: true,
+        name: true,
+        email: true,
+        password: true,
+        employeeNumber: true,
+        phoneNumber: true,
+        imageUrl: true,
+        isAdmin: true,
+        company: {
+          select: {
+            companyCode: true,
+          },
+        },
+        refreshToken: true,
+      },
+    });
+    if (!user) {
+      throw CustomError.notFound('존재하지 않는 유저입니다.');
+    }
+    return user;
+  };
+
+  update = async (data: UpdateUserDto, id: number): Promise<UserDTO> => {
+    const updatedUser: UserDTO = await prisma.user.update({
+      where: {
+        id,
+      },
+      data: data,
+      select: {
+        id: true,
+        name: true,
+        email: true,
+        password: true,
+        employeeNumber: true,
+        phoneNumber: true,
+        imageUrl: true,
+        isAdmin: true,
+        company: {
+          select: {
+            companyCode: true,
+          },
+        },
+        refreshToken: true,
+      },
+    });
+    return updatedUser;
   };
 }
 

--- a/src/repositories/userRepository.ts
+++ b/src/repositories/userRepository.ts
@@ -1,11 +1,21 @@
 import prisma from '../libs/prisma';
 import { User } from '../generated/prisma';
+import { CustomError } from '../utils/customErrorUtil';
 
 class UserRepository {
+  /**
+   *
+   * @param id userId 를 받습니다
+   * @returns 해당하는 user가 있는 경우 해당 유저의 정보를 리턴, 없는 경우 error을 throw합니다.
+   */
   getById = async (id: number): Promise<User> => {
-    const user: User = await prisma.user.findUniqueOrThrow({
+    const user: User | null = await prisma.user.findUnique({
       where: { id },
     });
+
+    if (!user) {
+      throw CustomError.notFound('존재하지 않는 유저입니다.');
+    }
 
     return user;
   };

--- a/src/routes/authRoute.ts
+++ b/src/routes/authRoute.ts
@@ -1,0 +1,10 @@
+import express, { Router } from 'express';
+import authController from '../controllers/authController';
+import auth from '../middlewares/auth';
+
+const authRouter: Router = express.Router();
+
+authRouter.route('/login').post(authController.login);
+authRouter.route('/refresh').post(auth.verifyRefreshToken, authController.updateToken);
+
+export default authRouter;

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -1,0 +1,50 @@
+import jwt from 'jsonwebtoken';
+import type { StringValue } from 'ms'; // jwt 토큰 expireIn 타입용
+import userRepository from '../repositories/userRepository';
+import { CustomError } from '../utils/customErrorUtil';
+import { TokenDTO } from '../types/authType';
+import { UserDTO } from '../types/userType';
+
+class AuthService {
+  /**
+   *
+   * @param user userId를 가져오기 위한 유저 정보
+   * @param type accessToken인지 refreshToken인지를 결정합니다
+   * @returns userId값으로 토큰을 만들어 유효기간이 정해진 토큰을 반환합니다.
+   */
+  createToken = (token: TokenDTO, type: string = 'access'): string => {
+    // 1. 환경 변수에 저장된 비밀키를 가져옵니다.
+    const secret = process.env.JWT_SECRET;
+    if (!secret) {
+      throw new CustomError('JWT_SECRET is not defined in the environment variables.', 500);
+    }
+    // 2-1. 토큰에 담을 정보와 유효기간을 설정합니다.
+    const payload = { userId: token.userId };
+    let expiresIn: StringValue = '1h';
+    // 2-2. 생성하고자 하는 토큰이 refreshToken일 경우 유효기간을 길게 설정합니다.
+    if (type === 'refresh') {
+      expiresIn = '2w';
+    }
+
+    // 3. 위 정보들을 바탕으로 토큰을 발급합니다.
+    return jwt.sign(payload, secret, { expiresIn });
+  };
+  /**
+   *
+   * @param userId 토큰을 재발행하고자 하는 유저의 id입니다.
+   * @param refreshToken 유저에게 전달받은 refreshToken입니다.
+   * @returns 새로운 accessToken을 발행하여 유저에게 반환합니다.
+   */
+  refreshingAccessToken = async (userId: number, refreshToken: string): Promise<string> => {
+    // 1. DB에 저장된 refreshToken을 가져오기 위해 유저 정보를 가져옵니다.
+    const user: UserDTO = await userRepository.getById(userId);
+    // 2. user의 저장된 토큰 정보와 유저에게 전달받은 토큰을 비교햐여 유효성을 검증합니다.
+    if (user.refreshToken !== refreshToken) {
+      throw CustomError.badRequest();
+    }
+    // 3. accessToken을 재발행하여 반환합니다.
+    return this.createToken({ userId: user.id });
+  };
+}
+
+export default new AuthService();

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -1,0 +1,34 @@
+import { LoginDTO, UpdateUserDto, UserDTO } from '../types/userType';
+import userRepository from '../repositories/userRepository';
+import hashUtil from '../utils/hashUtil';
+import { CustomError } from '../utils/customErrorUtil';
+
+class UserService {
+  getUser = async (loginDTO: LoginDTO): Promise<UserDTO> => {
+    // 1. 이메일로 유저를 조회합니다.
+    const user: UserDTO = await userRepository.getByEmail(loginDTO.email);
+    // 2. 조회한 유저의 비밀번호화 입력받은 비밀번호를 검증합니다.
+    if (!hashUtil.checkPassword(loginDTO.password, user.password!)) {
+      throw CustomError.notFound('존재하지 않거나 비밀번호가 일치하지 않습니다');
+    }
+    return user;
+  };
+
+  updateUser = async (updateUserDto: UpdateUserDto, id: number): Promise<UserDTO> => {
+    // 1. 전달받은 내용으로 user 정보를 업데이트 합니다.
+    const updatedUser: UserDTO = await userRepository.update(updateUserDto, id);
+    return updatedUser;
+  };
+
+  /**
+   *
+   * @param user 민감정보가 포함된 유저 객체입니다.
+   * @returns password, refreshToken과 같은 민감 정보가 제거된 유저 객체를 반환합니다.
+   */
+  filterSensitiveUserData = (user: UserDTO) => {
+    const { password, refreshToken, ...rest } = user;
+    return rest;
+  };
+}
+
+export default new UserService();

--- a/src/types/authType.ts
+++ b/src/types/authType.ts
@@ -1,0 +1,3 @@
+export interface TokenDTO {
+  userId: number;
+}

--- a/src/types/userType.ts
+++ b/src/types/userType.ts
@@ -1,0 +1,27 @@
+export type UpdateUserDto = Partial<{
+  employeeNumber: string;
+  phoneNumber: string;
+  password: string;
+  imageUrl: string | null;
+  refreshToken: string;
+}>;
+
+export interface UserDTO {
+  id: number;
+  name: string;
+  email: string;
+  password: string;
+  employeeNumber: string;
+  phoneNumber: string;
+  imageUrl: string | null;
+  isAdmin: boolean;
+  company: {
+    companyCode: string;
+  };
+  refreshToken: string | null;
+}
+
+export interface LoginDTO {
+  email: string;
+  password: string;
+}


### PR DESCRIPTION
### 주요 변경 사항
- 인증 - 로그인
- 인증 - 토큰갱신

두 API를 추가하였습니다.

### 사용법
- 로그인: "/auth/login" 경로로 email과 password값을 body에 담아 post 요청을 보냅니다.
- 토큰갱신: "/auth/refresh" 경로로 refreshToken을 body에 담아 post 요청을 보냅니다.

### 결과
- 로그인: 비밀번호를 제외한 유저 정보와 accessToken, refreshToken을 반환합니다.

<img width="849" height="756" alt="login예시" src="https://github.com/user-attachments/assets/35e5db85-a0dc-43fb-bc26-1497eb51c221" />

- 토큰갱신: DB에 저장된 refreshToken을 새로 업데이트 후, 갱신된 accessToken과 refreshToken을 반환합니다.

<img width="844" height="564" alt="rerfresh예시" src="https://github.com/user-attachments/assets/ff3c005e-4f26-4527-aad2-b7b0f2d739ba" />
