### PR TITLE
feat(prisma): migration 및 스키마에 따라 mock,seed 수정

### DIFF
--- a/prisma/migrations/20250827004042_fix_contract_document_relation/migration.sql
+++ b/prisma/migrations/20250827004042_fix_contract_document_relation/migration.sql
@@ -1,0 +1,29 @@
+/*
+  Warnings:
+
+  - The primary key for the `ContractDocument` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - You are about to drop the column `fileName` on the `ContractDocument` table. All the data in the column will be lost.
+  - You are about to drop the column `id` on the `ContractDocument` table. All the data in the column will be lost.
+  - You are about to drop the column `updatedAt` on the `ContractDocument` table. All the data in the column will be lost.
+  - Added the required column `documentId` to the `ContractDocument` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "public"."ContractDocument" DROP CONSTRAINT "ContractDocument_pkey",
+DROP COLUMN "fileName",
+DROP COLUMN "id",
+DROP COLUMN "updatedAt",
+ADD COLUMN     "documentId" INTEGER NOT NULL,
+ADD CONSTRAINT "ContractDocument_pkey" PRIMARY KEY ("contractId", "documentId");
+
+-- CreateTable
+CREATE TABLE "public"."Document" (
+    "id" SERIAL NOT NULL,
+    "fileName" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Document_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "public"."ContractDocument" ADD CONSTRAINT "ContractDocument_documentId_fkey" FOREIGN KEY ("documentId") REFERENCES "public"."Document"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/mock.ts
+++ b/prisma/mock.ts
@@ -1715,7 +1715,7 @@ export const CARS = [
     mileage: 10000,
     price: 0,
     accidentCount: 0,
-    status: 'contractCompleted',
+    status: 'possession',
     companyId: 2,
   },
   {
@@ -1725,7 +1725,7 @@ export const CARS = [
     mileage: 40144,
     price: 28809075,
     accidentCount: 0,
-    status: 'contractProceeding',
+    status: 'possession',
     companyId: 2,
   },
   {
@@ -1884,21 +1884,42 @@ export const MEETINGS = [
   },
 ];
 
-export const CONTRACT_DOCUMENTS = [
+export const DOCUMENTS = [
   {
-    fileName: 'contracts_example.csv',
-    contractId: 1,
+    fileName: 'contracts_example.jpeg',
   },
   {
     fileName: 'test_image.png',
-    contractId: 1,
   },
   {
     fileName: '계약서1.pdf',
-    contractId: 1,
   },
   {
     fileName: '계약서2.pdf',
+  },
+  {
+    fileName: '관계없는계약서.pdf',
+  },
+  {
+    fileName: '관계없는계약서2.pdf',
+  },
+];
+
+export const CONTRACT_DOCUMENTS = [
+  {
+    contractId: 1,
+    documentId: 1,
+  },
+  {
+    contractId: 1,
+    documentId: 2,
+  },
+  {
+    contractId: 1,
+    documentId: 3,
+  },
+  {
     contractId: 2,
+    documentId: 4,
   },
 ];

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -7,6 +7,7 @@ import {
   CAR_MODELS,
   CONTRACTS,
   MEETINGS,
+  DOCUMENTS,
   CONTRACT_DOCUMENTS,
 } from './mock';
 import hashUtil from '../src/utils/hashUtil';
@@ -25,6 +26,7 @@ async function main() {
       "CarModel", 
       "Contract", 
       "Meetings", 
+      "Document",
       "ContractDocument" 
     RESTART IDENTITY CASCADE
   `;
@@ -133,11 +135,21 @@ async function main() {
 
   // 계약서 데이터 삽입
   console.log('📄 계약서 데이터를 삽입합니다...');
-  for (const document of CONTRACT_DOCUMENTS) {
-    await prisma.contractDocument.create({
+  for (const document of DOCUMENTS) {
+    await prisma.document.create({
       data: {
         fileName: document.fileName,
-        contractId: document.contractId,
+      },
+    });
+  }
+
+  // 계약-계약서 관계 삽입
+  console.log('📄 계약-계약서 관계를 삽입합니다...');
+  for (const contractDocument of CONTRACT_DOCUMENTS) {
+    await prisma.contractDocument.create({
+      data: {
+        contractId: contractDocument.contractId,
+        documentId: contractDocument.documentId,
       },
     });
   }


### PR DESCRIPTION
## 주요 변경사항
- 어제 스키마 변경 후 migration을 하지 않아서 실행헀습니다.
- 수정된 스키마에 맞춰 `mock.ts`, `seed.ts`를 수정했습니다.

## 추가 변경사항
- mock 데이터의 `CARS` 일부 데이터를 `possesion` 상태로 수정했습니다.

## 참고사항
- `Document` 테이블의 5,6번 데이터는 중간테이블 데이터를 생성하지 않아 `Contract`와 연결되지 않도록 작성했습니다.