### PR TITLE
feat(prisma): 계약서 및 관계 모델 상호 CASCADE 설정 및 이름 변경

### DIFF
--- a/prisma/migrations/20250827021943_fix_naming/migration.sql
+++ b/prisma/migrations/20250827021943_fix_naming/migration.sql
@@ -1,0 +1,44 @@
+/*
+  Warnings:
+
+  - The primary key for the `ContractDocument` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - You are about to drop the column `contractId` on the `ContractDocument` table. All the data in the column will be lost.
+  - You are about to drop the column `documentId` on the `ContractDocument` table. All the data in the column will be lost.
+  - You are about to drop the `Document` table. If the table is not empty, all the data it contains will be lost.
+  - Added the required column `fileName` to the `ContractDocument` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- DropForeignKey
+ALTER TABLE "public"."ContractDocument" DROP CONSTRAINT "ContractDocument_contractId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "public"."ContractDocument" DROP CONSTRAINT "ContractDocument_documentId_fkey";
+
+-- AlterTable
+ALTER TABLE "public"."ContractDocument" DROP CONSTRAINT "ContractDocument_pkey",
+DROP COLUMN "contractId",
+DROP COLUMN "documentId",
+ADD COLUMN     "fileName" TEXT NOT NULL,
+ADD COLUMN     "id" SERIAL NOT NULL,
+ADD CONSTRAINT "ContractDocument_pkey" PRIMARY KEY ("id");
+
+-- DropTable
+DROP TABLE "public"."Document";
+
+-- CreateTable
+CREATE TABLE "public"."ContractDocumentRelation" (
+    "contractId" INTEGER NOT NULL,
+    "contractDocumentId" INTEGER NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ContractDocumentRelation_pkey" PRIMARY KEY ("contractId","contractDocumentId")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ContractDocumentRelation_contractDocumentId_key" ON "public"."ContractDocumentRelation"("contractDocumentId");
+
+-- AddForeignKey
+ALTER TABLE "public"."ContractDocumentRelation" ADD CONSTRAINT "ContractDocumentRelation_contractId_fkey" FOREIGN KEY ("contractId") REFERENCES "public"."Contract"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."ContractDocumentRelation" ADD CONSTRAINT "ContractDocumentRelation_contractDocumentId_fkey" FOREIGN KEY ("contractDocumentId") REFERENCES "public"."ContractDocument"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/mock.ts
+++ b/prisma/mock.ts
@@ -1884,7 +1884,7 @@ export const MEETINGS = [
   },
 ];
 
-export const DOCUMENTS = [
+export const CONTRACT_DOCUMENTS = [
   {
     fileName: 'contracts_example.jpeg',
   },
@@ -1905,21 +1905,21 @@ export const DOCUMENTS = [
   },
 ];
 
-export const CONTRACT_DOCUMENTS = [
+export const CONTRACT_DOCUMENT_RELATIONS = [
   {
     contractId: 1,
-    documentId: 1,
+    contractDocumentId: 1,
   },
   {
     contractId: 1,
-    documentId: 2,
+    contractDocumentId: 2,
   },
   {
     contractId: 1,
-    documentId: 3,
+    contractDocumentId: 3,
   },
   {
     contractId: 2,
-    documentId: 4,
+    contractDocumentId: 4,
   },
 ];

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -93,7 +93,7 @@ model Contract {
   company          Company            @relation(fields: [companyId], references: [id], onDelete: Cascade, onUpdate: Cascade)
   companyId        Int
   meetings         Meetings[]
-  contractDocument ContractDocument[]
+  contractDocumentRelation ContractDocumentRelation[]
   createdAt        DateTime           @default(now())
   updatedAt        DateTime           @updatedAt
 }
@@ -108,21 +108,21 @@ model Meetings {
   updatedAt  DateTime @updatedAt
 }
 
-model Document {
+model ContractDocument {
   id               Int                @id @default(autoincrement())
   fileName         String
-  contractDocument ContractDocument[]
+  contractDocumentRelation ContractDocumentRelation?
   createdAt        DateTime           @default(now())
 }
 
-model ContractDocument {
+model ContractDocumentRelation {
   contract   Contract @relation(fields: [contractId], references: [id], onDelete: Cascade, onUpdate: Cascade)
   contractId Int
-  document   Document @relation(fields: [documentId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  documentId Int
+  contractDocument   ContractDocument @relation(fields: [contractDocumentId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  contractDocumentId Int @unique
   createdAt  DateTime @default(now())
 
-  @@id([contractId, documentId])
+  @@id([contractId, contractDocumentId])
 }
 
 enum Gender {

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -7,8 +7,8 @@ import {
   CAR_MODELS,
   CONTRACTS,
   MEETINGS,
-  DOCUMENTS,
   CONTRACT_DOCUMENTS,
+  CONTRACT_DOCUMENT_RELATIONS,
 } from './mock';
 import hashUtil from '../src/utils/hashUtil';
 
@@ -26,8 +26,8 @@ async function main() {
       "CarModel", 
       "Contract", 
       "Meetings", 
-      "Document",
-      "ContractDocument" 
+      "ContractDocument",
+      "ContractDocumentRelation" 
     RESTART IDENTITY CASCADE
   `;
 
@@ -135,21 +135,21 @@ async function main() {
 
   // 계약서 데이터 삽입
   console.log('📄 계약서 데이터를 삽입합니다...');
-  for (const document of DOCUMENTS) {
-    await prisma.document.create({
+  for (const contractDocument of CONTRACT_DOCUMENTS) {
+    await prisma.contractDocument.create({
       data: {
-        fileName: document.fileName,
+        fileName: contractDocument.fileName,
       },
     });
   }
 
   // 계약-계약서 관계 삽입
   console.log('📄 계약-계약서 관계를 삽입합니다...');
-  for (const contractDocument of CONTRACT_DOCUMENTS) {
-    await prisma.contractDocument.create({
+  for (const contractDocumentRelation of CONTRACT_DOCUMENT_RELATIONS) {
+    await prisma.contractDocumentRelation.create({
       data: {
-        contractId: contractDocument.contractId,
-        documentId: contractDocument.documentId,
+        contractId: contractDocumentRelation.contractId,
+        contractDocumentId: contractDocumentRelation.contractDocumentId,
       },
     });
   }


### PR DESCRIPTION
## 주요 변경사항
- 계약 삭제 API의 요청에 따라 계약이 삭제되면 계약서가 삭제되도록 관계 테이블과 계약서 테이블간의 1:1관계 설정 및 상호간의 `onDelete: Cascade`를 설정했습니다.
- 계약서 모델명을 `ContractDocument`로, 계약-계약서 관계 모델명을 `ContractDocumentRelation`으로 수정했습니다.