### PR TITLE
feat(contractDocument): 계약서 문서 다운로드  구현

### DIFF
--- a/src/controllers/contractDocumentController.ts
+++ b/src/controllers/contractDocumentController.ts
@@ -19,6 +19,18 @@ class ContractDocumentController {
     // 4. 결과 반환
     return res.status(200).json(result);
   };
+
+  downloadContractDocument = async (req: Request, res: Response) => {
+    // 1. 파라미터 추출
+    const contractDocumentId = parseInt(req.params.contractDocumentId);
+
+    // 2. service 레이어 호출
+    const document = await contractDocumentService.getContractDocument(contractDocumentId);
+
+    // 3. 파일 다운로드 응답
+    const filePath = `document/${document.fileName}`;
+    return res.download(filePath);
+  };
 }
 
 export default new ContractDocumentController();

--- a/src/repositories/contractDocumentRepository.ts
+++ b/src/repositories/contractDocumentRepository.ts
@@ -13,6 +13,13 @@ class ContractDocumentRepository {
 
     return contractDocument;
   };
+
+  findById = async (contractDocumentId: number) => {
+    const contractDocument = await prisma.contractDocument.findUnique({
+      where: { id: contractDocumentId },
+    });
+    return contractDocument;
+  };
 }
 
 export default new ContractDocumentRepository();

--- a/src/routes/contractDocumentRoute.ts
+++ b/src/routes/contractDocumentRoute.ts
@@ -14,4 +14,9 @@ contractDocumentRouter
   .route('/upload')
   .post(uploadContractDocument.single('file'), contractDocumentController.uploadContractDocument);
 
+// 계약서 다운로드 (GET /contractDocuments/:contractDocumentId/download)
+contractDocumentRouter
+  .route('/:contractDocumentId/download')
+  .get(contractDocumentController.downloadContractDocument);
+
 export default contractDocumentRouter;

--- a/src/services/contractDocumentService.ts
+++ b/src/services/contractDocumentService.ts
@@ -27,7 +27,7 @@ class ContractDocumentService {
     // 계약서 문서 조회
     const contractDocument = await contractDocumentRepository.findById(contractDocumentId);
     if (!contractDocument) {
-      throw CustomError.badRequest('계약서 문서를 찾을 수 없습니다.');
+      throw CustomError.notFound('계약서 문서를 찾을 수 없습니다.');
     }
     return contractDocument;
   };

--- a/src/services/contractDocumentService.ts
+++ b/src/services/contractDocumentService.ts
@@ -1,4 +1,5 @@
 import contractDocumentRepository from '../repositories/contractDocumentRepository';
+import { CustomError } from '../utils/customErrorUtil';
 import type {
   UploadContractDocumentDTO,
   UploadContractDocumentResponseDTO,
@@ -17,6 +18,18 @@ class ContractDocumentService {
     return {
       contractDocumentId: contractDocument.id,
     };
+  };
+
+  /**
+   * 계약서 문서를 조회합니다.
+   */
+  getContractDocument = async (contractDocumentId: number) => {
+    // 계약서 문서 조회
+    const contractDocument = await contractDocumentRepository.findById(contractDocumentId);
+    if (!contractDocument) {
+      throw CustomError.badRequest('계약서 문서를 찾을 수 없습니다.');
+    }
+    return contractDocument;
   };
 }
 


### PR DESCRIPTION
## 주요 변경사항

- 계약서 문서 다운로드 기능을 구현했습니다.

## 참고사항

- 다운로드 테스트는 웹에서만 가능합니다.

### 테스트 방법
크롬 개발자 도구(F12) 콘솔에 헤더 설정 및 다운로드 실행 코드 입력

```js
fetch('/contractDocuments/:contractDocumentId/download', {
  headers: {
    'Authorization': 'Bearer {{accessToken}}'
  }
})
.then(response => {
  console.log('Status:', response.status);
  console.log('Headers:', response.headers);
  return response.blob();
})
.then(blob => {
  console.log('Blob size:', blob.size);
  // 다운로드 실행
  const url = window.URL.createObjectURL(blob);
  const a = document.createElement('a');
  a.href = url;
  a.download = 'test-file';
  a.click();
});
```