### PR TITLE
feat(company): 회사 등록, 수정, 삭제 API 추가

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -4,6 +4,7 @@ import cookieParser from 'cookie-parser';
 import express, { Express } from 'express';
 import { errorHandler } from './middlewares/errorHandler';
 import authRouter from './routes/authRoute';
+import companyRouter from './routes/companyRoute';
 import userRouter from './routes/userRoute';
 import contractRouter from './routes/contractRoute';
 import path from 'path';
@@ -19,6 +20,7 @@ app.use(express.json());
 app.use(cookieParser());
 
 app.use('/auth', authRouter);
+app.use('/companies', companyRouter);
 app.use('/users', userRouter);
 app.use('/contracts', contractRouter);
 

--- a/src/controllers/companyController.ts
+++ b/src/controllers/companyController.ts
@@ -1,0 +1,62 @@
+import { Request, Response } from 'express';
+import companyService from '../services/companyService';
+import {
+  createCompanySchema,
+  deleteCompanySchema,
+  updateCompanySchema,
+} from '../validators/companySchema';
+import { validator } from '../validators/utilValidator';
+import { CreateCompanyDTO, DeleteCompanyDTO, UpdateCompanyDTO } from '../types/companyType';
+
+class CompanyController {
+  createCompany = async (req: Request, res: Response) => {
+    // 1. DTO 정의
+    const createCompanyDTO: CreateCompanyDTO = {
+      companyName: req.body.companyName as string,
+      companyCode: req.body.companyCode as string,
+    };
+    // 2. 유효성 검사
+    validator(createCompanyDTO, createCompanySchema);
+    // 3. service레이어 호출
+    const company = await companyService.createCompany(createCompanyDTO);
+    // 4. 유저 정보 반환
+    return res.status(201).json(company);
+  };
+
+  updateCompany = async (req: Request, res: Response) => {
+    // 1. DTO 정의
+    const updateCompanyDTO: UpdateCompanyDTO = {
+      id: parseInt(req.params.companyId),
+      companyName: req.body.companyName as string,
+      companyCode: req.body.companyCode as string,
+    };
+    // 2. 유효성 검사
+    validator(
+      {
+        id: req.params.companyId,
+        companyName: req.body.companyName,
+        companyCode: req.body.companyCode,
+      },
+      updateCompanySchema,
+    );
+    // 3. service레이어 호출
+    const company = await companyService.updateCompany(updateCompanyDTO);
+    // 4. 유저 정보 반환
+    return res.status(201).json(company);
+  };
+
+  deleteCompany = async (req: Request, res: Response) => {
+    // 1. DTO 정의
+    const deleteCompanyDTO: DeleteCompanyDTO = {
+      id: parseInt(req.params.companyId),
+    };
+    // 2. 유효성 검사 - req.params로 받은 유저 값은 검증되지 않았으므로 체크
+    validator({ id: req.params.companyId }, deleteCompanySchema);
+    // 3. service레이어 호출
+    await companyService.deleteCompany(deleteCompanyDTO);
+    // 4. 삭제 성공 메세지 반환
+    return res.status(200).json({ message: '회사 삭제 성공' });
+  };
+}
+
+export default new CompanyController();

--- a/src/repositories/companyRepository.ts
+++ b/src/repositories/companyRepository.ts
@@ -22,12 +22,13 @@ class CompanyRepository {
   };
 
   create = async (createCompanyDTO: CreateCompanyDTO) => {
-    const company = await prisma.company.create({
+    let company = await prisma.company.create({
       data: createCompanyDTO,
       select: {
         id: true,
         companyName: true,
         companyCode: true,
+        _count: { select: { user: true } },
       },
     });
     return company;
@@ -42,6 +43,7 @@ class CompanyRepository {
         id: true,
         companyName: true,
         companyCode: true,
+        _count: { select: { user: true } },
       },
     });
     return company;

--- a/src/repositories/companyRepository.ts
+++ b/src/repositories/companyRepository.ts
@@ -1,4 +1,5 @@
 import prisma from '../libs/prisma';
+import { CreateCompanyDTO, UpdateCompanyDTO } from '../types/companyType';
 import { CustomError } from '../utils/customErrorUtil';
 
 class CompanyRepository {
@@ -18,6 +19,40 @@ class CompanyRepository {
       throw CustomError.notFound('존재하지 않는 회사입니다.');
     }
     return companyId.id;
+  };
+
+  create = async (createCompanyDTO: CreateCompanyDTO) => {
+    const company = await prisma.company.create({
+      data: createCompanyDTO,
+      select: {
+        id: true,
+        companyName: true,
+        companyCode: true,
+      },
+    });
+    return company;
+  };
+
+  update = async (updateCompanyDTO: UpdateCompanyDTO) => {
+    const { id, ...data } = updateCompanyDTO;
+    const company = await prisma.company.update({
+      where: { id },
+      data,
+      select: {
+        id: true,
+        companyName: true,
+        companyCode: true,
+      },
+    });
+    return company;
+  };
+
+  delete = async (companyId: number): Promise<void> => {
+    await prisma.company.delete({
+      where: {
+        id: companyId,
+      },
+    });
   };
 }
 

--- a/src/repositories/userRepository.ts
+++ b/src/repositories/userRepository.ts
@@ -140,13 +140,6 @@ class UserRepository {
       },
     });
   };
-
-  getUserCountByCompanyId = async (companyId: number): Promise<number> => {
-    const userCount = await prisma.user.count({
-      where: { companyId },
-    });
-    return userCount;
-  };
 }
 
 export default new UserRepository();

--- a/src/repositories/userRepository.ts
+++ b/src/repositories/userRepository.ts
@@ -140,6 +140,13 @@ class UserRepository {
       },
     });
   };
+
+  getUserCountByCompanyId = async (companyId: number): Promise<number> => {
+    const userCount = await prisma.user.count({
+      where: { companyId },
+    });
+    return userCount;
+  };
 }
 
 export default new UserRepository();

--- a/src/routes/companyRoute.ts
+++ b/src/routes/companyRoute.ts
@@ -1,0 +1,16 @@
+import express, { Router } from 'express';
+import companyController from '../controllers/companyController';
+import auth from '../middlewares/auth';
+
+const companyRouter: Router = express.Router();
+
+companyRouter
+  .route('/')
+  .post(auth.verifyAccessToken, auth.verifyAdminAuth, companyController.createCompany);
+
+companyRouter
+  .route('/:companyId')
+  .patch(auth.verifyAccessToken, auth.verifyAdminAuth, companyController.updateCompany)
+  .delete(auth.verifyAccessToken, auth.verifyAdminAuth, companyController.deleteCompany);
+
+export default companyRouter;

--- a/src/services/companyService.ts
+++ b/src/services/companyService.ts
@@ -7,20 +7,20 @@ class CompanyService {
   createCompany = async (createCompanyDTO: CreateCompanyDTO) => {
     // 1. 데이터 생성
     const company = await companyRepository.create(createCompanyDTO);
-    // 2. count 가져오기
-    const userCount = await userRepository.getUserCountByCompanyId(company.id);
+    // 2. count 분리
+    const { _count, ...companyData } = company;
     // 3. 회사 정보와 유저 수를 형식에 맞춰 반환
-    return { ...company, userCount };
+    return { ...companyData, userCount: _count.user };
   };
 
   updateCompany = async (updateCompanyDTO: UpdateCompanyDTO) => {
     try {
       // 1. 데이터 업데이트
       const company = await companyRepository.update(updateCompanyDTO);
-      // 2. count 가져오기
-      const userCount = await userRepository.getUserCountByCompanyId(company.id);
+      // 2. count 분리
+      const { _count, ...companyData } = company;
       // 3. 회사 정보와 유저 수를 형식에 맞춰 반환
-      return { ...company, userCount };
+      return { ...companyData, userCount: _count.user };
     } catch (err: any) {
       if (err.name === 'PrismaClientKnownRequestError' && (err as any).code === 'P2025') {
         throw CustomError.notFound('존재하지 않는 회사입니다');

--- a/src/services/companyService.ts
+++ b/src/services/companyService.ts
@@ -1,0 +1,46 @@
+import companyRepository from '../repositories/companyRepository';
+import userRepository from '../repositories/userRepository';
+import { CreateCompanyDTO, DeleteCompanyDTO, UpdateCompanyDTO } from '../types/companyType';
+import { CustomError } from '../utils/customErrorUtil';
+
+class CompanyService {
+  createCompany = async (createCompanyDTO: CreateCompanyDTO) => {
+    // 1. 데이터 생성
+    const company = await companyRepository.create(createCompanyDTO);
+    // 2. count 가져오기
+    const userCount = await userRepository.getUserCountByCompanyId(company.id);
+    // 3. 회사 정보와 유저 수를 형식에 맞춰 반환
+    return { ...company, userCount };
+  };
+
+  updateCompany = async (updateCompanyDTO: UpdateCompanyDTO) => {
+    try {
+      // 1. 데이터 업데이트
+      const company = await companyRepository.update(updateCompanyDTO);
+      // 2. count 가져오기
+      const userCount = await userRepository.getUserCountByCompanyId(company.id);
+      // 3. 회사 정보와 유저 수를 형식에 맞춰 반환
+      return { ...company, userCount };
+    } catch (err: any) {
+      if (err.name === 'PrismaClientKnownRequestError' && (err as any).code === 'P2025') {
+        throw CustomError.notFound('존재하지 않는 회사입니다');
+      } else {
+        throw err;
+      }
+    }
+  };
+
+  deleteCompany = async (deleteCompanyDTO: DeleteCompanyDTO) => {
+    try {
+      await userRepository.delete(deleteCompanyDTO.id);
+    } catch (err: any) {
+      if (err.name === 'PrismaClientKnownRequestError' && (err as any).code === 'P2025') {
+        throw CustomError.notFound('존재하지 않는 회사입니다');
+      } else {
+        throw err;
+      }
+    }
+  };
+}
+
+export default new CompanyService();

--- a/src/types/companyType.ts
+++ b/src/types/companyType.ts
@@ -1,0 +1,12 @@
+export interface CreateCompanyDTO {
+  companyName: string;
+  companyCode: string;
+}
+
+export interface UpdateCompanyDTO extends CreateCompanyDTO {
+  id: number;
+}
+
+export interface DeleteCompanyDTO {
+  id: number;
+}

--- a/src/validators/companySchema.ts
+++ b/src/validators/companySchema.ts
@@ -1,0 +1,23 @@
+import { object, size, string, refine } from 'superstruct';
+import { utilValidator } from './utilValidator';
+
+const createCompanySchema = object({
+  companyName: utilValidator.companyName,
+  companyCode: size(string(), 1, 20), // 별도 제한이 없었던것 같기에 길이만 검사
+});
+
+const updateCompanySchema = object({
+  id: refine(string(), 'idError', (value) => {
+    return /^[0-9]+$/.test(value);
+  }),
+  companyName: utilValidator.companyName,
+  companyCode: size(string(), 1, 20), // 별도 제한이 없었던것 같기에 길이만 검사
+});
+
+const deleteCompanySchema = object({
+  id: refine(string(), 'idError', (value) => {
+    return /^[0-9]+$/.test(value);
+  }),
+});
+
+export { createCompanySchema, updateCompanySchema, deleteCompanySchema };


### PR DESCRIPTION
### 주요 변경 사항
- 회사 - 회사등록
  - 회사이름(companyName)과 회사코드(companyCode)를 request body로 전달받아 회사를 생성합니다
  - 회사 이름과 회사 코드를 DB에 등록하고 해당 회사의 id, 이름, 코드, 인원수를 반환합니다.

- 회사 - 회사수정
  - 회사 id를 path 파라미터로, 회사이름과 회사코드를 request body로 받아 이용하여 회사 정보를 수정합니다
  - 회사 id에 맞는 데이터의 회사 이름과 회사 코드 업데이트하고 해당 회사의 id, 이름, 코드, 인원수를 반환합니다.

- 회사 - 회사삭제
  - 회사 id를 path 파라미터로 받아 해당하는 회사정보를 DB에서 삭제합니다.
 
회사 등록, 수정, 삭제 세 신규 API를 추가하였습니다.

### 사용법
- 회사 등록: "/companies" 경로로 아래 값을 request body에 담아 post 요청을 보냅니다. 
  - 어드민 계정으로 로그인이 되어 있어야 합니다(액세스 토큰 설정 필요)
  - 받을 수 있는 정보는 아래와 같습니다
    - companyName: string (필수값)
    - companyCode: string (필수값)
 
- 회사 수정: "/companies/:companyId" 경로로 아래 값을 request body에 담아 patch 요청을 보냅니다. 
  - 어드민 계정으로 로그인이 되어 있어야 합니다(액세스 토큰 설정 필요)
  - 받을 수 있는 정보는 아래와 같습니다
    - companyName: string (필수값)
    - companyCode: string (필수값)
    
- 회사 삭제: "/companies/:companyId" 경로로 delete 요청을 보냅니다. 
  - 어드민 계정으로 로그인이 되어 있어야 합니다(액세스 토큰 설정 필요)
    
### 결과
- 회사 등록: 회사 이름과 회사 코드를 DB에 등록하고 해당 회사의 id, 이름, 코드, 인원수를 반환합니다.

<img width="865" height="494" alt="회사-등록" src="https://github.com/user-attachments/assets/c49b3ff9-f0e5-4c26-ae77-46dba654133b" />


- 회사 수정: 회사 id에 맞는 데이터의 회사 이름과 회사 코드 업데이트하고 해당 회사의 id, 이름, 코드, 인원수를 반환합니다. 

<img width="868" height="503" alt="회사-수정" src="https://github.com/user-attachments/assets/d12c010b-0e0e-407e-9495-118b843bdbb2" />


- 회사 삭제: 회사 id에 맞는 데이터를 DB에서 제거합니다.

<img width="866" height="451" alt="회사-삭제" src="https://github.com/user-attachments/assets/1230cb6c-b270-40c6-8e34-a13892ee46b7" />


###기타
수정, 삭제시 casacde로 설정되어 있기에 관계가 있는 데이터들은 함께 지워지게 됩니다. (예시 : 회사-유저)