### PR TITLE
feat(customer): 고객 삭제, 수정, 상세 조회 가능 추가

### DIFF
--- a/src/controllers/customerController.ts
+++ b/src/controllers/customerController.ts
@@ -29,6 +29,37 @@ class CustomerController {
       next(error);
     }
   };
+
+  updateCustomer = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const customerId = parseInt(req.params.customerId, 10);
+      const customerData = req.body;
+      const result = await customerService.updateCustomer(customerId, customerData);
+      res.status(200).json(result);
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  deleteCustomer = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const customerId = parseInt(req.params.customerId, 10);
+      await customerService.deleteCustomer(customerId);
+      res.status(200).json({ message: '고객 삭제 성공' });
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  getCustomer = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const customerId = parseInt(req.params.customerId, 10);
+      const result = await customerService.getCustomer(customerId);
+      res.status(200).json(result);
+    } catch (error) {
+      next(error);
+    }
+  };
 }
 
 export default new CustomerController();

--- a/src/repositories/customerRepository.ts
+++ b/src/repositories/customerRepository.ts
@@ -110,8 +110,61 @@ class CustomerRepository {
         where: searchCondition,
       }),
     ]);
-
     return { customers, totalCount };
+  };
+
+  updateCustomer = async (customerId: number, data: CreateCustomerDTO) => {
+    const prismaData = {
+      ...data,
+      ageGroup: data.ageGroup ? ageGroupMap[data.ageGroup] : undefined,
+      region: data.region ? regionMap[data.region] : undefined,
+    };
+
+    const customer = await prisma.customer.update({
+      where: { id: customerId },
+      data: prismaData,
+      select: {
+        id: true,
+        name: true,
+        gender: true,
+        phoneNumber: true,
+        ageGroup: true,
+        region: true,
+        email: true,
+        memo: true,
+        _count: {
+          select: { contract: true },
+        },
+      },
+    });
+    return customer;
+  };
+
+  deleteCustomer = async (customerId: number) => {
+    const customer = await prisma.customer.delete({
+      where: { id: customerId },
+    });
+    return customer;
+  };
+
+  getCustomer = async (customerId: number) => {
+    const customer = await prisma.customer.findUnique({
+      where: { id: customerId },
+      select: {
+        id: true,
+        name: true,
+        gender: true,
+        phoneNumber: true,
+        ageGroup: true,
+        region: true,
+        email: true,
+        memo: true,
+        _count: {
+          select: { contract: true },
+        },
+      },
+    });
+    return customer;
   };
 }
 

--- a/src/routes/customerRoute.ts
+++ b/src/routes/customerRoute.ts
@@ -8,5 +8,10 @@ customerRouter
   .route('/')
   .post(auth.verifyAccessToken, auth.verifyUserAuth, customerController.createCustomer)
   .get(auth.verifyAccessToken, auth.verifyUserAuth, customerController.getCustomerList);
+customerRouter
+  .route('/:customerId')
+  .get(auth.verifyAccessToken, auth.verifyUserAuth, customerController.getCustomer)
+  .patch(auth.verifyAccessToken, auth.verifyUserAuth, customerController.updateCustomer)
+  .delete(auth.verifyAccessToken, auth.verifyUserAuth, customerController.deleteCustomer);
 
 export default customerRouter;

--- a/src/services/customerService.ts
+++ b/src/services/customerService.ts
@@ -78,7 +78,6 @@ class CustomerService {
     );
     const formattedCustomers = customers.map((customer) => {
       const { _count, ...rest } = customer;
-
       return {
         ...rest,
         ageGroup: rest.ageGroup ? reverseAgeGroupMap[rest.ageGroup] : undefined,
@@ -93,6 +92,43 @@ class CustomerService {
       data: formattedCustomers,
     };
     return result;
+  };
+
+  updateCustomer = async (customerId: number, data: CreateCustomerDTO) => {
+    const customer = await customerRepository.updateCustomer(customerId, data);
+    if (!customer) {
+      throw CustomError.notFound('존재하지 않는 고객입니다.');
+    }
+    const { _count, ...rest } = customer;
+    const resCustomer = {
+      ...rest,
+      ageGroup: rest.ageGroup ? reverseAgeGroupMap[rest.ageGroup] : undefined,
+      region: rest.region ? reverseRegionMap[rest.region] : undefined,
+      contractCount: _count.contract,
+    };
+    return resCustomer;
+  };
+
+  deleteCustomer = async (customerId: number) => {
+    const customer = await customerRepository.deleteCustomer(customerId);
+    if (!customer) {
+      throw CustomError.notFound('존재하지 않는 고객입니다.');
+    }
+  };
+
+  getCustomer = async (customerId: number) => {
+    const customer = await customerRepository.getCustomer(customerId);
+    if (!customer) {
+      throw CustomError.notFound('존재하지 않는 고객입니다.');
+    }
+    const { _count, ...rest } = customer;
+    const resCustomer = {
+      ...rest,
+      ageGroup: rest.ageGroup ? reverseAgeGroupMap[rest.ageGroup] : undefined,
+      region: rest.region ? reverseRegionMap[rest.region] : undefined,
+      contractCount: _count.contract,
+    };
+    return resCustomer;
   };
 }
 


### PR DESCRIPTION
## 요약 (Summary)

이번 PR은 기존에 구현된 고객 기능에 이어서, 특정 고객의 정보를 수정하고, 삭제하며, 상세 정보를 조회하는 API를 구현했습니다.

* **고객 정보 수정 API (PATCH)**: 클라이언트로부터 받은 `customerId`와 업데이트 데이터를 바탕으로 고객 정보를 수정합니다.
* **고객 정보 삭제 API (DELETE)**: `customerId`를 사용하여 고객 데이터를 삭제합니다.
* **고객 상세 조회 API (GET)**: `customerId`를 사용하여 특정 고객의 상세 정보를 조회합니다.

모든 API는 요청된 고객이 존재하지 않을 경우 **404 Not Found** 응답을 반환하여 잘못된 요청을 방지합니다.

---

## 주요 변경 사항 (Major Changes)

### **고객 정보 수정 API (PATCH /api/customers/:customerId)**

* **고객 존재 여부 확인**: 수정하려는 고객이 데이터베이스에 존재하는지 확인하는 로직을 추가했습니다.
* **데이터 매핑**: 응답 데이터에 포함된 `ageGroup`과 `region` 값을 Prisma의 Enum 형식에서 한글 값으로 변환하는 매핑 로직을 적용했습니다.
* **계약 건수 포함**: 고객이 체결한 계약 건수(`contractCount`)를 응답 데이터에 포함했습니다.

### **고객 정보 삭제 API (DELETE /api/customers/:customerId)**

* **안전한 삭제**: 삭제하려는 고객이 존재하는지 확인한 후, 존재할 경우에만 삭제를 진행합니다.
* **예외 처리**: 존재하지 않는 고객에 대한 요청이 들어오면 **404 Not Found** 응답을 반환합니다.

### **고객 상세 정보 조회 API (GET /api/customers/:customerId)**

* **고객 존재 여부 확인**: 조회하려는 고객이 데이터베이스에 존재하는지 확인하는 로직을 추가했습니다.
* **데이터 매핑**: 응답 데이터의 `ageGroup`과 `region`을 한글 값으로 변환하는 매핑 로직을 적용했습니다.
* **계약 건수 포함**: 고객이 체결한 계약 건수(`contractCount`)를 함께 반환하도록 구현했습니다.

---

## API 응답 명세 (Responses)

### **고객 정보 수정 API**

* **`200 OK`**: 성공적으로 고객 정보가 수정되었을 때 반환되며, 수정된 고객 정보를 포함합니다.
* **`400 Bad Request`**: 요청 본문이 잘못되었거나 필수 필드가 누락되었을 때 반환됩니다.
* **`401 Unauthorized`**: `Authorization` 헤더가 없거나 토큰이 유효하지 않을 때 반환됩니다.
* **`404 Not Found`**: 요청된 `customerId`에 해당하는 고객이 없을 때 반환됩니다.

### **고객 삭제 API**

* **`200 OK`**: 고객 삭제에 성공했을 때 반환됩니다.
* **`400 Bad Request`**: `customerId`가 잘못되었을 때 반환됩니다.
* **`401 Unauthorized`**: `Authorization` 헤더가 없거나 토큰이 유효하지 않을 때 반환됩니다.
* **`404 Not Found`**: 요청된 `customerId`에 해당하는 고객이 없을 때 반환됩니다.

### **고객 상세 정보 조회 API**

* **`200 OK`**: 성공적으로 고객 정보가 조회되었을 때 반환되며, 상세 고객 정보를 포함합니다.
* **`400 Bad Request`**: `customerId`가 잘못되었을 때 반환됩니다.
* **`401 Unauthorized`**: `Authorization` 헤더가 없거나 토큰이 유효하지 않을 때 반환됩니다.
* **`404 Not Found`**: 요청된 `customerId`에 해당하는 고객이 없을 때 반환됩니다.