### PR TITLE
feat(contractDocument): 계약서 목록 조회 API 추가 및 관련 로직 구현

### DIFF
--- a/src/controllers/contractDocumentController.ts
+++ b/src/controllers/contractDocumentController.ts
@@ -11,10 +11,10 @@ class ContractDocumentController {
     };
 
     // 2. 유효성 검사 및 검증된 DTO 반환
-    const validatedDTO = uploadContractDocumentValidator(uploadDTO);
+    uploadContractDocumentValidator(uploadDTO);
 
     // 3. service 레이어 호출
-    const result = await contractDocumentService.uploadContractDocument(validatedDTO);
+    const result = await contractDocumentService.uploadContractDocument(uploadDTO);
 
     // 4. 결과 반환
     return res.status(200).json(result);

--- a/src/controllers/contractDocumentController.ts
+++ b/src/controllers/contractDocumentController.ts
@@ -1,7 +1,12 @@
 import { Request, Response } from 'express';
 import contractDocumentService from '../services/contractDocumentService';
 import { uploadContractDocumentValidator } from '../validators/contractDocumentValidator';
-import type { UploadContractDocumentDTO } from '../types/contractDocumentType';
+import type {
+  UploadContractDocumentDTO,
+  GetContractDocumentsParamsDTO,
+} from '../types/contractDocumentType';
+import { validator } from '../validators/utilValidator';
+import { getContractDocumentsParamsSchema } from '../validators/contractDocumentValidator';
 
 class ContractDocumentController {
   uploadContractDocument = async (req: Request, res: Response) => {
@@ -30,6 +35,26 @@ class ContractDocumentController {
     // 3. 파일 다운로드 응답
     const filePath = `document/${document.fileName}`;
     return res.download(filePath);
+  };
+
+  getContractDocumentList = async (req: Request, res: Response) => {
+    // 1. 파라미터 검증
+    validator(req.query, getContractDocumentsParamsSchema);
+
+    // 2. 파라미터 추출
+    const userId = req.user!.userId;
+    const params: GetContractDocumentsParamsDTO = {
+      page: req.query.page ? parseInt(req.query.page as string, 10) : 1,
+      pageSize: req.query.pageSize ? parseInt(req.query.pageSize as string, 10) : 10,
+      searchBy: req.query.searchBy as 'contractName' | 'manager' | 'carNumber' | undefined,
+      keyword: req.query.keyword as string | undefined,
+    };
+
+    // 3. service 레이어 호출
+    const result = await contractDocumentService.getContractDocumentList(params, userId);
+
+    // 4. 결과 반환
+    return res.status(200).json(result);
   };
 }
 

--- a/src/repositories/contractDocumentRepository.ts
+++ b/src/repositories/contractDocumentRepository.ts
@@ -1,4 +1,6 @@
 import prisma from '../libs/prisma';
+import { Prisma } from '../generated/prisma';
+import type { GetContractDocumentsParamsDTO } from '../types/contractDocumentType';
 
 class ContractDocumentRepository {
   /**
@@ -19,6 +21,136 @@ class ContractDocumentRepository {
       where: { id: contractDocumentId },
     });
     return contractDocument;
+  };
+
+  /**
+   * 계약서 목록을 조회합니다.
+   */
+  findContractDocumentList = async (
+    { page, pageSize, searchBy, keyword }: GetContractDocumentsParamsDTO,
+    companyId: number,
+  ) => {
+    // 검색 조건 구성
+    let whereCondition: Prisma.ContractWhereInput = {
+      companyId,
+    };
+
+    if (searchBy && keyword && keyword.trim() !== '') {
+      switch (searchBy) {
+        case 'contractName':
+          // 계약명 검색: 차량 모델명과 고객명으로 검색
+          whereCondition.OR = [
+            {
+              car: {
+                model: {
+                  contains: keyword,
+                  mode: 'insensitive',
+                },
+              },
+            },
+            {
+              customer: {
+                name: {
+                  contains: keyword,
+                  mode: 'insensitive',
+                },
+              },
+            },
+          ];
+          break;
+        case 'manager':
+          whereCondition.user = {
+            name: {
+              contains: keyword,
+              mode: 'insensitive',
+            },
+          };
+          break;
+        case 'carNumber':
+          whereCondition.car = {
+            carNumber: {
+              contains: keyword,
+              mode: 'insensitive',
+            },
+          };
+          break;
+      }
+    }
+
+    // 전체 개수 조회
+    const totalItemCount = await prisma.contract.count({
+      where: whereCondition,
+    });
+
+    // 페이지네이션 계산
+    const currentPage = page || 1;
+    const currentPageSize = pageSize || 8;
+    const skip = (currentPage - 1) * currentPageSize;
+    const totalPages =
+      totalItemCount % currentPageSize === 0
+        ? totalItemCount / currentPageSize
+        : (totalItemCount - (totalItemCount % currentPageSize)) / currentPageSize + 1;
+
+    // 계약서 목록 조회
+    const contracts = await prisma.contract.findMany({
+      where: whereCondition,
+      select: {
+        id: true,
+        resolutionDate: true,
+        user: {
+          select: {
+            name: true,
+          },
+        },
+        car: {
+          select: {
+            carNumber: true,
+            model: true,
+          },
+        },
+        customer: {
+          select: {
+            name: true,
+          },
+        },
+        contractDocumentRelation: {
+          select: {
+            contractDocument: {
+              select: {
+                id: true,
+                fileName: true,
+              },
+            },
+          },
+        },
+      },
+      skip,
+      take: currentPageSize,
+      orderBy: {
+        id: 'desc',
+      },
+    });
+
+    // 응답 데이터 변환
+    const data = contracts.map((contract) => ({
+      id: contract.id,
+      contractName: `${contract.car.model} - ${contract.customer.name} 고객님`,
+      resolutionDate: contract.resolutionDate,
+      documentCount: contract.contractDocumentRelation.length,
+      manager: contract.user.name,
+      carNumber: contract.car.carNumber,
+      documents: contract.contractDocumentRelation.map((relation) => ({
+        id: relation.contractDocument.id,
+        fileName: relation.contractDocument.fileName,
+      })),
+    }));
+
+    return {
+      currentPage,
+      totalPages,
+      totalItemCount,
+      data,
+    };
   };
 }
 

--- a/src/routes/contractDocumentRoute.ts
+++ b/src/routes/contractDocumentRoute.ts
@@ -19,4 +19,7 @@ contractDocumentRouter
   .route('/:contractDocumentId/download')
   .get(contractDocumentController.downloadContractDocument);
 
+// 계약서 목록 조회 (GET /contractDocuments)
+contractDocumentRouter.route('/').get(contractDocumentController.getContractDocumentList);
+
 export default contractDocumentRouter;

--- a/src/services/contractDocumentService.ts
+++ b/src/services/contractDocumentService.ts
@@ -1,9 +1,11 @@
 import contractDocumentRepository from '../repositories/contractDocumentRepository';
-import { CustomError } from '../utils/customErrorUtil';
+import contractRepository from '../repositories/contractRepository';
 import type {
   UploadContractDocumentDTO,
   UploadContractDocumentResponseDTO,
+  GetContractDocumentsParamsDTO,
 } from '../types/contractDocumentType';
+import { CustomError } from '../utils/customErrorUtil';
 
 class ContractDocumentService {
   /**
@@ -30,6 +32,25 @@ class ContractDocumentService {
       throw CustomError.notFound('계약서 문서를 찾을 수 없습니다.');
     }
     return contractDocument;
+  };
+
+  /**
+   * 계약서 목록을 조회합니다.
+   */
+  getContractDocumentList = async (
+    { page, pageSize, searchBy, keyword }: GetContractDocumentsParamsDTO,
+    userId: number,
+  ) => {
+    // 사용자의 회사 ID 조회
+    const companyId = await contractRepository.getCompanyId(userId);
+
+    // 계약서 목록 조회
+    const result = await contractDocumentRepository.findContractDocumentList(
+      { page, pageSize, searchBy, keyword },
+      companyId,
+    );
+
+    return result;
   };
 }
 

--- a/src/types/contractDocumentType.ts
+++ b/src/types/contractDocumentType.ts
@@ -5,3 +5,31 @@ export interface UploadContractDocumentDTO {
 export interface UploadContractDocumentResponseDTO {
   contractDocumentId: number;
 }
+
+// 계약서 목록 조회를 위한 타입들
+export type GetContractDocumentsParamsDTO = {
+  page?: number;
+  pageSize?: number;
+  searchBy?: 'contractName' | 'manager' | 'carNumber';
+  keyword?: string;
+};
+
+export type OffsetPagination<T> = {
+  currentPage: number;
+  totalPages: number;
+  totalItemCount: number;
+  data: T[];
+};
+
+export type ContractDocumentListDTO = {
+  id: number;
+  contractName: string;
+  resolutionDate: string | null;
+  documentCount: number;
+  manager: string;
+  carNumber: string;
+  documents: {
+    id: number;
+    fileName: string;
+  }[];
+};

--- a/src/validators/contractDocumentValidator.ts
+++ b/src/validators/contractDocumentValidator.ts
@@ -1,4 +1,4 @@
-import { object, create, string } from 'superstruct';
+import { assert, object, string } from 'superstruct';
 import { UploadContractDocumentDTO } from '../types/contractDocumentType';
 
 /**
@@ -6,14 +6,12 @@ import { UploadContractDocumentDTO } from '../types/contractDocumentType';
  * @param uploadDTO fileName을 입력받아 형식을 검증하는 validator 입니다.
  * @returns 검증된 DTO 객체
  */
-const uploadContractDocumentValidator = (
-  uploadDTO: UploadContractDocumentDTO,
-): UploadContractDocumentDTO => {
+const uploadContractDocumentValidator = (uploadDTO: UploadContractDocumentDTO) => {
   const uploadStruct = object({
     fileName: string(),
   });
 
-  return create(uploadDTO, uploadStruct);
+  assert(uploadDTO, uploadStruct);
 };
 
 export { uploadContractDocumentValidator };

--- a/src/validators/contractDocumentValidator.ts
+++ b/src/validators/contractDocumentValidator.ts
@@ -1,4 +1,4 @@
-import { assert, object, string } from 'superstruct';
+import { assert, object, string, optional, enums, refine } from 'superstruct';
 import { UploadContractDocumentDTO } from '../types/contractDocumentType';
 
 /**
@@ -15,3 +15,21 @@ const uploadContractDocumentValidator = (uploadDTO: UploadContractDocumentDTO) =
 };
 
 export { uploadContractDocumentValidator };
+
+// 계약서 목록 조회 파라미터 검증 스키마
+const SearchByContractDocument = ['contractName', 'manager', 'carNumber'];
+
+export const getContractDocumentsParamsSchema = object({
+  page: optional(
+    refine(string(), 'pageError', (value) => {
+      return /^\d+$/.test(value) && Number(value) >= 1;
+    }),
+  ),
+  pageSize: optional(
+    refine(string(), 'pageSizeError', (value) => {
+      return /^\d+$/.test(value) && Number(value) >= 1 && Number(value) <= 50;
+    }),
+  ),
+  searchBy: optional(enums(SearchByContractDocument)),
+  keyword: optional(string()),
+});


### PR DESCRIPTION
## 주요 변경사항

- 계약서 목록 조회 기능을 레이어별로 구현하였습니다.

## 추가 변경사항

- 유효성 검사에서 assert를 사용하도록 변경하였습니다.

## 참고사항

- 계약명 검색기능을 위해서 `{model} - ${customerName} 고객님` 형식으로 계약명을 만들었습니다.
- 차량 목록 조회를 참고하여 구현하였습니다.
