### PR TITLE
feat(contractDocument): 계약 추가 시 계약 목록 조회 API 추가 및 로직 레이어 이동

### DIFF
--- a/src/controllers/contractDocumentController.ts
+++ b/src/controllers/contractDocumentController.ts
@@ -45,7 +45,7 @@ class ContractDocumentController {
     const userId = req.user!.userId;
     const params: GetContractDocumentsParamsDTO = {
       page: req.query.page ? parseInt(req.query.page as string, 10) : 1,
-      pageSize: req.query.pageSize ? parseInt(req.query.pageSize as string, 10) : 10,
+      pageSize: req.query.pageSize ? parseInt(req.query.pageSize as string, 10) : 8,
       searchBy: req.query.searchBy as 'contractName' | 'manager' | 'carNumber' | undefined,
       keyword: req.query.keyword as string | undefined,
     };
@@ -55,6 +55,17 @@ class ContractDocumentController {
 
     // 4. 결과 반환
     return res.status(200).json(result);
+  };
+
+  getDraftContractList = async (req: Request, res: Response) => {
+    // 1. 사용자 ID 추출
+    const userId = req.user!.userId;
+
+    // 2. service 레이어 호출
+    const draftContracts = await contractDocumentService.getDraftContractList(userId);
+
+    // 3. 결과 반환
+    return res.status(200).json(draftContracts);
   };
 }
 

--- a/src/routes/contractDocumentRoute.ts
+++ b/src/routes/contractDocumentRoute.ts
@@ -22,4 +22,7 @@ contractDocumentRouter
 // 계약서 목록 조회 (GET /contractDocuments)
 contractDocumentRouter.route('/').get(contractDocumentController.getContractDocumentList);
 
+// 계약서 추가 시 계약 목록 조회 (GET /contractDocuments/draft)
+contractDocumentRouter.route('/draft').get(contractDocumentController.getDraftContractList);
+
 export default contractDocumentRouter;

--- a/src/types/contractDocumentType.ts
+++ b/src/types/contractDocumentType.ts
@@ -33,3 +33,37 @@ export type ContractDocumentListDTO = {
     fileName: string;
   }[];
 };
+
+// Repository에서 반환하는 원시 데이터 타입
+export interface ContractDocumentRawData {
+  contracts: Array<{
+    id: number;
+    resolutionDate: Date | null;
+    user: { name: string };
+    car: { carNumber: string; model: string };
+    customer: { name: string };
+    contractDocumentRelation: Array<{
+      contractDocument: { id: number; fileName: string };
+    }>;
+  }>;
+  totalItemCount: number;
+  page: number;
+  pageSize: number;
+}
+
+// 드롭다운 타입
+export interface DropdownDTO {
+  id: number;
+  data: string;
+}
+
+// 드래프트 계약 조회 결과 타입
+export interface DraftContractDTO {
+  id: number;
+  car: {
+    model: string;
+  };
+  customer: {
+    name: string;
+  };
+}


### PR DESCRIPTION
## 주요 변경사항
- 계약 추가 시 계약 목록 조회 구현
- 계약서 목록 조회의 페이지 수 계산과 응답 데이터 변환 로직을 `Repository`레이어에서 `Service`레이어로 이동

## 추가 변경사항

- `pageSize`의 기본값을 8으로 통일