### PR TITLE
feat(user): 회사 목록 조회 API 추가

### DIFF
--- a/src/controllers/companyController.ts
+++ b/src/controllers/companyController.ts
@@ -5,8 +5,13 @@ import {
   deleteCompanySchema,
   updateCompanySchema,
 } from '../validators/companySchema';
-import { validator } from '../validators/utilValidator';
-import { CreateCompanyDTO, DeleteCompanyDTO, UpdateCompanyDTO } from '../types/companyType';
+import { validator, paginationStruct } from '../validators/utilValidator';
+import {
+  CreateCompanyDTO,
+  DeleteCompanyDTO,
+  UpdateCompanyDTO,
+  GetCompanyListDTO,
+} from '../types/companyType';
 
 class CompanyController {
   createCompany = async (req: Request, res: Response) => {
@@ -56,6 +61,22 @@ class CompanyController {
     await companyService.deleteCompany(deleteCompanyDTO);
     // 4. 삭제 성공 메세지 반환
     return res.status(200).json({ message: '회사 삭제 성공' });
+  };
+
+  getCompanyList = async (req: Request, res: Response) => {
+    // 1. DTO 정의
+    const getCompanyListDTO: GetCompanyListDTO = {
+      page: Number(req.query.page) ? Number(req.query.page) : undefined,
+      pageSize: Number(req.query.pageSize) ? Number(req.query.pageSize) : undefined,
+      searchBy: req.query.searchBy as string | undefined,
+      keyword: req.query.keyword as string | undefined,
+    };
+    // 2. 유효성 검사 - req.params로 받은 유저 값은 검증되지 않았으므로 체크
+    validator({ page: req.query.page, pageSize: req.query.pageSize }, paginationStruct);
+    // 3. service레이어 호출
+    const { companies, pageInfo } = await companyService.getCompanyList(getCompanyListDTO);
+    // 4. 삭제 성공 메세지 반환
+    return res.status(200).json({ ...pageInfo, data: companies });
   };
 }
 

--- a/src/repositories/companyRepository.ts
+++ b/src/repositories/companyRepository.ts
@@ -1,4 +1,5 @@
 import prisma from '../libs/prisma';
+import { Prisma } from '../generated/prisma';
 import { CreateCompanyDTO, UpdateCompanyDTO } from '../types/companyType';
 import { CustomError } from '../utils/customErrorUtil';
 
@@ -55,6 +56,36 @@ class CompanyRepository {
         id: companyId,
       },
     });
+  };
+
+  getCompanyList = async (page: number, pageSize: number, where: Prisma.CompanyWhereInput) => {
+    const skip = (page - 1) * pageSize;
+    const take = pageSize;
+
+    const [data, totalItemCount] = await Promise.all([
+      // 페이지네이션 된 회사 정보
+      prisma.company.findMany({
+        where,
+        skip,
+        take,
+        select: {
+          id: true,
+          companyCode: true,
+          companyName: true,
+          _count: { select: { user: true } },
+        },
+      }),
+      // 페이지에 포함되지 않는 전체 아이템 수까지 가져오기
+      prisma.company.count({
+        where,
+      }),
+    ]);
+
+    // 페이지네이션 된 회사 정보들과 조건에 맞는 데이터 개수 전체 반환
+    return {
+      data,
+      totalItemCount,
+    };
   };
 }
 

--- a/src/routes/companyRoute.ts
+++ b/src/routes/companyRoute.ts
@@ -6,6 +6,7 @@ const companyRouter: Router = express.Router();
 
 companyRouter
   .route('/')
+  .get(auth.verifyAccessToken, auth.verifyAdminAuth, companyController.getCompanyList)
   .post(auth.verifyAccessToken, auth.verifyAdminAuth, companyController.createCompany);
 
 companyRouter

--- a/src/services/companyService.ts
+++ b/src/services/companyService.ts
@@ -1,6 +1,12 @@
+import { Prisma } from '../generated/prisma';
 import companyRepository from '../repositories/companyRepository';
 import userRepository from '../repositories/userRepository';
-import { CreateCompanyDTO, DeleteCompanyDTO, UpdateCompanyDTO } from '../types/companyType';
+import {
+  CreateCompanyDTO,
+  DeleteCompanyDTO,
+  GetCompanyListDTO,
+  UpdateCompanyDTO,
+} from '../types/companyType';
 import { CustomError } from '../utils/customErrorUtil';
 
 class CompanyService {
@@ -40,6 +46,45 @@ class CompanyService {
         throw err;
       }
     }
+  };
+
+  getCompanyList = async (getCompanyListDTO: GetCompanyListDTO) => {
+    const { page = 1, pageSize = 8, searchBy = 'companyName', keyword = '' } = getCompanyListDTO;
+    // 1. searchBy의 값이 유효한지 검사
+    const validSearchBy = ['companyName'];
+    if (searchBy && !validSearchBy.includes(searchBy)) {
+      throw CustomError.badRequest();
+    }
+    // 2. 검색 조건 설정, 추후 확장 가능성도 있으므로 where 조건을 else if 로 확장할 수 있게 구성
+    let where: Prisma.CompanyWhereInput = {};
+    if (searchBy === 'companyName') {
+      where = {
+        ...where,
+        companyName: {
+          contains: keyword,
+          mode: 'insensitive',
+        },
+      };
+    }
+    // 3. 회사 목록 검색
+    const { data, totalItemCount } = await companyRepository.getCompanyList(page, pageSize, where);
+
+    // 4-1. 회사 정보 형식 변환
+    const formattedCompanies = data.map((company) => {
+      const { _count, ...companyData } = company;
+      return { ...companyData, userCount: _count.user };
+    });
+    // 4-2. 페이지 정보
+    const pageInfo = {
+      currentPage: page,
+      totalPages:
+        totalItemCount % pageSize === 0
+          ? totalItemCount / pageSize
+          : (totalItemCount - (totalItemCount % pageSize)) / pageSize + 1,
+      totalItemCount,
+    };
+    // 5. 데이터 반환
+    return { companies: formattedCompanies, pageInfo };
   };
 }
 

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -53,7 +53,6 @@ class UserService {
     if (data.password) {
       data.password = hashUtil.hashPassword(data.password);
     }
-    console.log(data);
     // 3-1. 비밀번호 비교를 위해 유저 정보를 가져옵니다.
     const oldUser = await userRepository.getById(id);
     if (!oldUser) {

--- a/src/types/companyType.ts
+++ b/src/types/companyType.ts
@@ -10,3 +10,10 @@ export interface UpdateCompanyDTO extends CreateCompanyDTO {
 export interface DeleteCompanyDTO {
   id: number;
 }
+
+export interface GetCompanyListDTO {
+  page?: number;
+  pageSize?: number;
+  searchBy?: string;
+  keyword?: string;
+}


### PR DESCRIPTION
### 주요 변경 사항
- 회사 - 회사 목록 조회
  - 서비스에 등록된 회사 목록을 조회합니다.
 
회사 목록 조회 API를 추가하였습니다.

### 사용법
- 회사 목록 조회: "/companies" 경로로 get 요청을 보냅니다. 
  - 어드민 계정으로 로그인이 되어 있어야 합니다(액세스 토큰 설정 필요)
  -  쿼리 파라미터로 아래와 같은 파라미터를 넘길 수 있습니다
    - page : 검색하고자 하는 페이지 번호 (생략시 1)
    - pageSize : 한 페이지의 크기 (생략시 8)
    - searchBy : keyword 검색할 조건 (현재는 companyName만 가능합니다, 생략시 기본 companyName)
    - keyword : 검색할때 keyword가 포함된 회사만 조회

### 결과
- 회사 목록 조회: currentPage, totalPages, totalItemCount, 회사 리스트를 조회합니다.
<img width="866" height="765" alt="회사-목록조회" src="https://github.com/user-attachments/assets/0a953a2d-0b64-4e79-9bfe-b8705403fdda" />
