### PR TITLE
feat(company): 회사별 유저 목록 조회 API 추가

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,6 @@
+# port
+PORT=3000
+
 # Database
 DATABASE_URL="postgresql://postgres:password@localhost:5432/dear_carmate?schema=public"
 

--- a/src/controllers/companyController.ts
+++ b/src/controllers/companyController.ts
@@ -11,6 +11,7 @@ import {
   DeleteCompanyDTO,
   UpdateCompanyDTO,
   GetCompanyListDTO,
+  GetCompanyUserListDTO,
 } from '../types/companyType';
 
 class CompanyController {
@@ -71,12 +72,28 @@ class CompanyController {
       searchBy: req.query.searchBy as string | undefined,
       keyword: req.query.keyword as string | undefined,
     };
-    // 2. 유효성 검사 - req.params로 받은 유저 값은 검증되지 않았으므로 체크
+    // 2. 유효성 검사 - req.query로 받은 유저 값은 검증되지 않았으므로 체크
     validator({ page: req.query.page, pageSize: req.query.pageSize }, paginationStruct);
     // 3. service레이어 호출
     const { companies, pageInfo } = await companyService.getCompanyList(getCompanyListDTO);
     // 4. 삭제 성공 메세지 반환
     return res.status(200).json({ ...pageInfo, data: companies });
+  };
+
+  getCompanyUserList = async (req: Request, res: Response) => {
+    // 1. DTO 정의
+    const getCompanyUserListDTO: GetCompanyUserListDTO = {
+      page: Number(req.query.page) ? Number(req.query.page) : undefined,
+      pageSize: Number(req.query.pageSize) ? Number(req.query.pageSize) : undefined,
+      searchBy: req.query.searchBy as string | undefined,
+      keyword: req.query.keyword as string | undefined,
+    };
+    // 2. 유효성 검사 - req.query로 받은 유저 값은 검증되지 않았으므로 체크
+    validator({ page: req.query.page, pageSize: req.query.pageSize }, paginationStruct);
+    // 3. service레이어 호출
+    const { data, pageInfo } = await companyService.getCompanyUserList(getCompanyUserListDTO);
+    // 4. 삭제 성공 메세지 반환
+    return res.status(200).json({ ...pageInfo, data });
   };
 }
 

--- a/src/controllers/companyController.ts
+++ b/src/controllers/companyController.ts
@@ -76,7 +76,7 @@ class CompanyController {
     validator({ page: req.query.page, pageSize: req.query.pageSize }, paginationStruct);
     // 3. service레이어 호출
     const { companies, pageInfo } = await companyService.getCompanyList(getCompanyListDTO);
-    // 4. 삭제 성공 메세지 반환
+    // 4. 페이지 정보 및 회사 정보 반환
     return res.status(200).json({ ...pageInfo, data: companies });
   };
 
@@ -92,7 +92,7 @@ class CompanyController {
     validator({ page: req.query.page, pageSize: req.query.pageSize }, paginationStruct);
     // 3. service레이어 호출
     const { data, pageInfo } = await companyService.getCompanyUserList(getCompanyUserListDTO);
-    // 4. 삭제 성공 메세지 반환
+    // 4. 페이지 정보 및 유저 정보 반환
     return res.status(200).json({ ...pageInfo, data });
   };
 }

--- a/src/repositories/userRepository.ts
+++ b/src/repositories/userRepository.ts
@@ -1,3 +1,4 @@
+import { Prisma } from '../generated/prisma';
 import prisma from '../libs/prisma';
 import { CreateUserDTO, UpdateUserDTO, UserDTO } from '../types/userType';
 
@@ -104,6 +105,40 @@ class UserRepository {
       },
     });
     return user;
+  };
+
+  getUserList = async (page: number, pageSize: number, where: Prisma.UserWhereInput) => {
+    const skip = (page - 1) * pageSize;
+    const take = pageSize;
+
+    const [data, totalItemCount] = await Promise.all([
+      // 페이지네이션 된 유저 정보
+      prisma.user.findMany({
+        where,
+        skip,
+        take,
+        select: {
+          id: true,
+          name: true,
+          email: true,
+          employeeNumber: true,
+          phoneNumber: true,
+          company: {
+            select: { companyName: true },
+          },
+        },
+      }),
+      // 페이지에 포함되지 않는 전체 아이템 수까지 가져오기
+      prisma.user.count({
+        where,
+      }),
+    ]);
+
+    // 페이지네이션 된 유저 정보들과 조건에 맞는 데이터 개수 전체 반환
+    return {
+      data,
+      totalItemCount,
+    };
   };
 
   update = async (updataUserDTO: UpdateUserDTO, id: number): Promise<UserDTO> => {

--- a/src/routes/companyRoute.ts
+++ b/src/routes/companyRoute.ts
@@ -10,6 +10,10 @@ companyRouter
   .post(auth.verifyAccessToken, auth.verifyAdminAuth, companyController.createCompany);
 
 companyRouter
+  .route('/users')
+  .get(auth.verifyAccessToken, auth.verifyAdminAuth, companyController.getCompanyUserList);
+
+companyRouter
   .route('/:companyId')
   .patch(auth.verifyAccessToken, auth.verifyAdminAuth, companyController.updateCompany)
   .delete(auth.verifyAccessToken, auth.verifyAdminAuth, companyController.deleteCompany);

--- a/src/services/companyService.ts
+++ b/src/services/companyService.ts
@@ -5,6 +5,7 @@ import {
   CreateCompanyDTO,
   DeleteCompanyDTO,
   GetCompanyListDTO,
+  GetCompanyUserListDTO,
   UpdateCompanyDTO,
 } from '../types/companyType';
 import { CustomError } from '../utils/customErrorUtil';
@@ -85,6 +86,63 @@ class CompanyService {
     };
     // 5. 데이터 반환
     return { companies: formattedCompanies, pageInfo };
+  };
+
+  getCompanyUserList = async (getCompanyUserListDTO: GetCompanyUserListDTO) => {
+    const {
+      page = 1,
+      pageSize = 8,
+      searchBy = 'companyName',
+      keyword = '',
+    } = getCompanyUserListDTO;
+    // 1. searchBy의 값이 유효한지 검사
+    const validSearchBy = ['companyName', 'email', 'name'];
+    if (searchBy && !validSearchBy.includes(searchBy)) {
+      throw CustomError.badRequest();
+    }
+    // 2. 검색 조건 설정, 추후 확장 가능성도 있으므로 where 조건을 else if 로 확장할 수 있게 구성
+    let where: Prisma.UserWhereInput = {};
+    if (searchBy === 'companyName') {
+      where = {
+        ...where,
+        company: {
+          companyName: {
+            contains: keyword,
+            mode: 'insensitive',
+          },
+        },
+      };
+    } else if (searchBy === 'email') {
+      where = {
+        ...where,
+        email: {
+          contains: keyword,
+          mode: 'default', // 이메일은 대소문자 구분
+        },
+      };
+    } else if (searchBy === 'name') {
+      where = {
+        ...where,
+        name: {
+          contains: keyword,
+          mode: 'insensitive',
+        },
+      };
+    }
+    // 3. 회사 목록 검색
+    const { data, totalItemCount } = await userRepository.getUserList(page, pageSize, where);
+
+    // 4. 페이지 정보
+    const pageInfo = {
+      currentPage: page,
+      totalPages:
+        totalItemCount % pageSize === 0
+          ? totalItemCount / pageSize
+          : (totalItemCount - (totalItemCount % pageSize)) / pageSize + 1,
+      totalItemCount,
+    };
+    // 5. 데이터 반환
+    return { data, pageInfo };
   };
 }
 

--- a/src/types/companyType.ts
+++ b/src/types/companyType.ts
@@ -17,3 +17,5 @@ export interface GetCompanyListDTO {
   searchBy?: string;
   keyword?: string;
 }
+
+export interface GetCompanyUserListDTO extends GetCompanyListDTO {}


### PR DESCRIPTION
### 주요 변경 사항
- 회사 - 회사별 유저 목록 조회
  - 조건에 해당하는 유저 목록을 조회합니다.
 
회사 유저 목록 조회 API를 추가하였습니다.

### 사용법
- 회사 유저 목록 조회: "/companies/users" 경로로 get 요청을 보냅니다. 
  - 어드민 계정으로 로그인이 되어 있어야 합니다(액세스 토큰 설정 필요)
  -  쿼리 파라미터로 아래와 같은 파라미터를 넘길 수 있습니다
    - page : 검색하고자 하는 페이지 번호 (생략시 1)
    - pageSize : 한 페이지의 크기 (생략시 8)
    - searchBy : keyword 검색할 조건 
      - companyName, name, email 중 1개
      - email의 경우 대소문자를 구분합니다.
      - 생략시 기본 companyName
    - keyword : 검색할때 keyword가 포함된 회사만 조회

### 결과
- 회사별 유저 목록 조회: currentPage, totalPages, totalItemCount, 유저 리스트를 조회합니다
<img width="860" height="675" alt="회사-유저목록조회" src="https://github.com/user-attachments/assets/ce83553e-c109-44c9-a69a-6a8430412b82" />



### 비고
- 동작하는 로직상 user에 해당하는 기능이나 companies로 요청하기에 company의 router, controller, service에 해당 기능을 추가하였습니다.
- .env.example에 PORT 변수를 추가하였습니다