### PR TITLE
fix(error): instance of가 CustomError를 인식하지 못했던 문제 수정

### DIFF
--- a/src/utils/customErrorUtil.ts
+++ b/src/utils/customErrorUtil.ts
@@ -4,6 +4,7 @@ export class CustomError extends Error {
   constructor(message: string, code: number) {
     super(message);
     this.code = code;
+    Object.setPrototypeOf(this, CustomError.prototype);
   }
 
   // 400 Bad Request


### PR DESCRIPTION
### 주요 변경 사항
Error 클래스를 상속한 Custom Error가 build -> start 명령어로 배포시
instance of로 인식되지 않았던 문제를 수정하였습니다

### 참고
https://github.com/Microsoft/TypeScript/wiki/FAQ#why-doesnt-extending-built-ins-like-error-array-and-map-work